### PR TITLE
fix(fahchen): revert renames

### DIFF
--- a/lib/jet_cli/generator.ex
+++ b/lib/jet_cli/generator.ex
@@ -1,4 +1,4 @@
-defmodule JetCLI.Generator do
+defmodule JetCli.Generator do
   @moduledoc false
 
   defmacro templates(files) do

--- a/lib/jet_cli/injector/deps.ex
+++ b/lib/jet_cli/injector/deps.ex
@@ -1,4 +1,4 @@
-defmodule JetCLI.Injector.Deps do
+defmodule JetCli.Injector.Deps do
   @moduledoc """
   Inject deps into `mix.exs` file.
   """

--- a/lib/mix/tasks/jet_cli.init.ci.ex
+++ b/lib/mix/tasks/jet_cli.init.ci.ex
@@ -1,8 +1,8 @@
-defmodule Mix.Tasks.JetCLI.Init.CI do
+defmodule Mix.Tasks.JetCli.Init.Ci do
   use Mix.Task
 
   import Mix.Generator
-  import JetCLI.Generator
+  import JetCli.Generator
 
   @shortdoc "Init CI (GitHub Actions) for the Elixir project"
 
@@ -137,7 +137,7 @@ defmodule Mix.Tasks.JetCLI.Init.CI do
   ]
 
   defp inject_deps!(dir) do
-    alias JetCLI.Injector.Deps
+    alias JetCli.Injector.Deps
 
     mix_file = target_file("mix.exs", dir)
 

--- a/mix.exs
+++ b/mix.exs
@@ -9,7 +9,7 @@ defmodule JetCli.MixProject do
   def project do
     [
       app: :jet_cli,
-      version: "0.2.0",
+      version: "0.2.1",
       elixir: "~> 1.14",
       description: "The CLI for Jet Team.",
       source_url: "https://github.com/Byzanteam/jet_cli",

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ for path <- :code.get_path(),
   Code.delete_path(path)
 end
 
-defmodule JetCLI.MixProject do
+defmodule JetCli.MixProject do
   use Mix.Project
 
   def project do

--- a/test/jet_cli/injector/deps_test.exs
+++ b/test/jet_cli/injector/deps_test.exs
@@ -1,7 +1,7 @@
-defmodule JetCLI.Injector.DepsTest do
+defmodule JetCli.Injector.DepsTest do
   use ExUnit.Case, async: true
 
-  alias JetCLI.Injector.Deps
+  alias JetCli.Injector.Deps
 
   test "injects deps" do
     content = """

--- a/test/mix/tasks/jet_cli.init.ci_test.exs
+++ b/test/mix/tasks/jet_cli.init.ci_test.exs
@@ -1,10 +1,10 @@
 Mix.shell(Mix.Shell.Process)
 
-defmodule Mix.Tasks.JetCLI.Init.CITest do
+defmodule Mix.Tasks.JetCli.Init.CiTest do
   use ExUnit.Case, async: true
 
   import MixHelper
-  alias Mix.Tasks.JetCLI.Init.CI
+  alias Mix.Tasks.JetCli.Init.Ci
 
   @moduletag :tmp_dir
 
@@ -23,7 +23,7 @@ defmodule Mix.Tasks.JetCLI.Init.CITest do
       """
     )
 
-    CI.run([tmp_dir])
+    Ci.run([tmp_dir])
 
     in_repo(tmp_dir, fn ->
       assert_file(".github/workflows/elixir.yml", fn file ->
@@ -41,7 +41,7 @@ defmodule Mix.Tasks.JetCLI.Init.CITest do
       """
     )
 
-    CI.run([tmp_dir, "--enable-database"])
+    Ci.run([tmp_dir, "--enable-database"])
 
     in_repo(tmp_dir, fn ->
       assert_file(".github/workflows/elixir.yml", fn file ->
@@ -51,7 +51,7 @@ defmodule Mix.Tasks.JetCLI.Init.CITest do
   end
 
   test "generates the .credo.exs file and skip incompatible rules", %{tmp_dir: tmp_dir} do
-    CI.run([tmp_dir])
+    Ci.run([tmp_dir])
 
     in_repo(tmp_dir, fn ->
       assert_file(".credo.exs", fn file ->
@@ -69,7 +69,7 @@ defmodule Mix.Tasks.JetCLI.Init.CITest do
       """
     )
 
-    CI.run([tmp_dir])
+    Ci.run([tmp_dir])
 
     in_repo(tmp_dir, fn ->
       assert_file(".credo.exs", fn file ->
@@ -80,11 +80,11 @@ defmodule Mix.Tasks.JetCLI.Init.CITest do
 
   test "PATH is required", context do
     assert_raise Mix.Error, ~r/The PATH dose not exist, or it is not a directory/, fn ->
-      CI.run(["not-existing"])
+      Ci.run(["not-existing"])
     end
 
     assert_raise Mix.Error, ~r/The PATH dose not exist, or it is not a directory/, fn ->
-      CI.run([context.file])
+      Ci.run([context.file])
     end
   end
 
@@ -92,7 +92,7 @@ defmodule Mix.Tasks.JetCLI.Init.CITest do
     File.rm!(Path.expand("mix.exs", tmp_dir))
 
     assert_raise Mix.Error, ~r/`mix.exs` file dose not exist/, fn ->
-      CI.run([tmp_dir])
+      Ci.run([tmp_dir])
     end
   end
 
@@ -100,7 +100,7 @@ defmodule Mix.Tasks.JetCLI.Init.CITest do
     File.rm!(Path.expand(".tool-versions", tmp_dir))
 
     assert_raise Mix.Error, ~r/`.tool-versions` file dose not exist/, fn ->
-      CI.run([tmp_dir])
+      Ci.run([tmp_dir])
     end
   end
 
@@ -122,7 +122,7 @@ defmodule Mix.Tasks.JetCLI.Init.CITest do
     File.write!(
       Path.expand("mix.exs", tmp_dir),
       """
-        defmodule JetCLITest.MixProject do
+        defmodule JetCliTest.MixProject do
           use Mix.Project
 
           def project do


### PR DESCRIPTION
- [x] Revert "fix: rename Cli and Ci to CLI and CI (#5)"

```log
module name in object code is 'Elixir.Mix.Tasks.JetCLI.Init.CI'



15:22:13.722 [error] beam/beam_load.c(180): Error loading module 'Elixir.Mix.Tasks.JetCli.Init.Ci':
  module name in object code is 'Elixir.Mix.Tasks.JetCLI.Init.CI'



15:22:13.719 [error] Loading of ~/.mix/archives/jet_cli-0.2.0/jet_cli-0.2.0/ebin/Elixir.Mix.Tasks.JetCli.Init.Ci.beam failed: :badfile


15:22:13.722 [error] Loading of ~/.mix/archives/jet_cli-0.2.0/jet_cli-0.2.0/ebin/Elixir.Mix.Tasks.JetCli.Init.Ci.beam failed: :badfile


15:22:13.832 [error] Loading of ~/.mix/archives/jet_cli-0.2.0/jet_cli-0.2.0/ebin/Elixir.Mix.Tasks.JetCli.Init.Ci.beam failed: :badfile


15:22:13.832 [error] beam/beam_load.c(180): Error loading module 'Elixir.Mix.Tasks.JetCli.Init.Ci':
  module name in object code is 'Elixir.Mix.Tasks.JetCLI.Init.CI'



15:22:13.875 [error] beam/beam_load.c(180): Error loading module 'Elixir.Mix.Tasks.JetCli.Init.Ci':
  module name in object code is 'Elixir.Mix.Tasks.JetCLI.Init.CI'



15:22:13.875 [error] Loading of ~/.mix/archives/jet_cli-0.2.0/jet_cli-0.2.0/ebin/Elixir.Mix.Tasks.JetCli.Init.Ci.beam failed: :badfile

** (Mix) The task "jet_cli.init.ci" could not be found because the module is named Mix.Tasks.JetCLI.Init.CI instead of Mix.Tasks.JetCli.Init.Ci as expected. Please rename it and try again
```
